### PR TITLE
Fix errors on crystal 0.15.0

### DIFF
--- a/spec/html_builder_spec.cr
+++ b/spec/html_builder_spec.cr
@@ -1,5 +1,5 @@
 require "./spec_helper"
-require "html/builder"
+require "../src/html/builder"
 
 describe HTML::Builder do
   it "builds html" do
@@ -17,7 +17,7 @@ describe HTML::Builder do
         end
       end
     end
-    str.should eq %(<!DOCTYPE html><html><head><title>Crystal Programming Language</title></head><body><a href="http://crystal-lang.org">Crystal rocks!</a><form method="POST"><input name="name"></form></body></html>)
+    str.should eq %(<!DOCTYPE html><html><head><title>Crystal Programming Language</title></head><body><a href="http://crystal-lang.org">Crystal rocks&#33;</a><form method="POST"><input name="name"></form></body></html>)
   end
 
   it "builds html with some tag attributes" do
@@ -26,7 +26,7 @@ describe HTML::Builder do
         text "Crystal rocks!"
       end
     end
-    str.should eq %(<a href="http://crystal-lang.org" class="crystal" id="main">Crystal rocks!</a>)
+    str.should eq %(<a href="http://crystal-lang.org" class="crystal" id="main">Crystal rocks&#33;</a>)
   end
 
   it "builds html with an provided html string" do
@@ -40,7 +40,7 @@ describe HTML::Builder do
     str = HTML::Builder.new.build do
       tag("section", {class: "crystal"}) { text "Crystal rocks!" }
     end
-    str.should eq %(<section class="crystal">Crystal rocks!</section>)
+    str.should eq %(<section class="crystal">Crystal rocks&#33;</section>)
   end
 
   it "escapes attribute values" do

--- a/src/html/builder/builder.cr
+++ b/src/html/builder/builder.cr
@@ -88,7 +88,7 @@ struct HTML::Builder
   # end
   # # => <section class="crystal">crystal is awesome</section>
   # ```
-  def tag(name, attrs = nil : Hash(Symbol, String)?)
+  def tag(name, attrs : Hash(Symbol, String)? = nil  )
     @str << "<#{name}"
     append_attributes_string(attrs)
     @str << ">"
@@ -105,7 +105,7 @@ struct HTML::Builder
     # end
     # # => <{{tag.id}} class="crystal">crystal is awesome</{{tag.id}}>
     # ```
-    def {{tag.id}}(attrs = nil : Hash(Symbol, String)?)
+    def {{tag.id}}(attrs : Hash(Symbol, String)? = nil)
       @str << "<{{tag.id}}"
       append_attributes_string(attrs)
       @str << ">"
@@ -123,7 +123,7 @@ struct HTML::Builder
     # end
     # # => <{{tag.id}} class="crystal">
     # ```
-    def {{tag.id}}(attrs = nil : Hash(Symbol, String)?)
+    def {{tag.id}}(attrs : Hash(Symbol, String)? = nil)
       @str << "<{{tag.id}}"
       append_attributes_string(attrs)
       @str << ">"


### PR DESCRIPTION
Details:
- Correct the syntax of a method argument with a default value and a type restriction.
- Correct a few spec conditions ( "!" in text will be escaped to "&amp;#33;" ).