### PR TITLE
Crystal 0.21.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: html_builder
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - Ary Borenszweig <aborenszweig@manas.com.ar>

--- a/src/html/builder/builder.cr
+++ b/src/html/builder/builder.cr
@@ -25,7 +25,7 @@ struct HTML::Builder
   end
 
   def initialize
-    @str = MemoryIO.new
+    @str = IO::Memory.new
   end
 
   def build


### PR DESCRIPTION
`MemoryIO` has been renamed to `IO::Memory`. That's everything that's needed for running the `README.md` sample in Crystal 0.21.0.