### PR TITLE
Follow crystal 1.0.0 in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: html_builder
 version: 0.2.2
+crystal: '< 2.0.0'
 
 authors:
   - Ary Borenszweig <aborenszweig@manas.com.ar>


### PR DESCRIPTION
```console
$ crystal --version
Crystal 1.0.0 (2021-03-22)

LLVM: 9.0.1
Default target: x86_64-apple-macosx

$ crystal spec
........

Finished in 728 microseconds
8 examples, 0 failures, 0 errors, 0 pending
```

So I think this shard will work in crystal 1.0.0 ☺️ 
But, using `shards` command in a directory... (e.g. https://github.com/crystal-jp/introducing-crystal/blob/7066d90abef3c469ef8426ae21e4f57adaa93148/05-shards/projects/simple_html/shard.yml#L17)

```
  Resolving dependencies
  Fetching https://github.com/crystal-lang/html_builder.git
  Unable to satisfy the following requirements:

  - `crystal (< 1.0.0)` required by `html_builder 0.2.2`
  Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update
is available.
```

I didn't know detail about shards, so looking into https://github.com/crystal-lang/shards/blob/addc26a3f22fee9fccb01cbb3e8878bef02d4295/docs/shard.yml.adoc

>Note | If this property is not included it is treated as < 1.0.0.

So this change might remove the needless error for shards users? 🤔 

