### PR TITLE
Add Github Actions and more examples to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download source
+        uses: actions/checkout@v3
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+
+      - name: Run tests
+        run: crystal spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,30 @@
+name: Weekly CI
+on:
+  schedule:
+    - cron: 0 0 * * 1 # At 00:00 on Monday
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: ubuntu-latest, crystal: latest}
+          - {os: ubuntu-latest, crystal: nightly}
+          - {os: macos-latest}
+          - {os: windows-latest}
+
+    name: Tests
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Download source
+        uses: actions/checkout@v3
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{matrix.crystal}}
+          shards: false
+
+      - name: Run tests
+        run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dependencies:
 
 ## Usage
 
-
+#### Basic usage
 ```crystal
 require "html_builder"
 
@@ -25,9 +25,105 @@ html = HTML.build do
   end
 end
 
-puts html # => %(<a href="http://crystal-lang.org">crystal is awesome</a>)
+puts html
 ```
 
+**Output** (this output is formatted for better display):
+```html
+<a href="http://crystal-lang.org">
+  crystal is awesome
+</a>
+```
+
+
+#### Full HTML5 page
+```crystal
+html = HTML.build do
+  doctype
+  html(lang: "pt-BR") do
+    head do
+      title { text "Crystal Programming Language" }
+
+      meta(charset: "UTF-8")
+    end
+    body do
+      a(href: "http://crystal-lang.org") { text "Crystal rocks!" }
+      form(method: "POST") do
+        input(name: "name")
+      end
+    end
+  end
+end
+
+puts html
+```
+
+**Output** :
+```html
+<!DOCTYPE html>
+
+<html lang="pt-BR">
+  <head>
+    <title>Crystal Programming Language</title>
+
+    <meta charset="UTF-8">
+  </head>
+
+  <body>
+    <a href="http://crystal-lang.org">Crystal rocks!</a>
+    <form method="POST">
+      <input name="name">
+    </form>
+  </body>
+</html>
+```
+
+#### Custom tags
+
+```crystal
+html = HTML.build do
+  tag("v-button", to: "home") { text "Home" }
+end
+
+puts html
+```
+
+**Output**:
+```html
+<v-button to="home">
+  Home
+</v-button>
+```
+
+#### Safety
+
+HTML::Builder escapes attribute values:
+```crystal
+html = HTML.build do
+  a(href: "<>") { }
+end
+
+puts html
+```
+
+**Output**:
+```html
+<a href="&lt;&gt;"></a>
+```
+
+And escapes text:
+```crystal
+html = HTML.build do
+  a { text "<>" }
+end
+
+puts html
+```
+
+**Output**:
+```html
+<a>&lt;&gt;</a>
+```
 ## Contributing
 
 1. Fork it ( https://github.com/crystal-lang/html_builder/fork )


### PR DESCRIPTION
- Adding two Github Actions workflows:
  - Run tests on push
  - Run tests against latest and nightly crystal on Ubuntu/MacOS/Windows every week

 - Adding more examples to README.md